### PR TITLE
Enable usage with Django 1.10's MIDDLEWARE setting

### DIFF
--- a/pagination/middleware.py
+++ b/pagination/middleware.py
@@ -1,3 +1,10 @@
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    # Fallback for Django < 1.10
+    MiddlewareMixin = object
+
+
 def get_page(self):
     """
     A function which will be monkeypatched onto the request to get the current
@@ -8,7 +15,8 @@ def get_page(self):
     except (KeyError, ValueError, TypeError):
         return 1
 
-class PaginationMiddleware(object):
+
+class PaginationMiddleware(MiddlewareMixin):
     """
     Inserts a variable representing the current page onto the request object if
     it exists in either **GET** or **POST** portions of the request.


### PR DESCRIPTION
Utilises Django's MiddlewareMixin so that django-pagination's Middleware can perform across versions.